### PR TITLE
fix wildcards processing

### DIFF
--- a/lib/Script/Sieve.php
+++ b/lib/Script/Sieve.php
@@ -290,7 +290,7 @@ class Ingo_Script_Sieve extends Ingo_Script_Base
             }
 
             if (count($wildcards) == 5) {
-                $wildcards_todo[] = $temp;
+                $wildcards_todo[] = $wildcards;
                 $wildcards = array();
             }
         }


### PR DESCRIPTION
This was probably a copy & paste mistake.
It caused "empty" sieve rules to be created.