### PR TITLE
fix: continue vs break in Imap.php

### DIFF
--- a/lib/Script/Imap.php
+++ b/lib/Script/Imap.php
@@ -276,7 +276,7 @@ class Ingo_Script_Imap extends Ingo_Script_Base
                         /* We need to grab the envelope first. */
                         if ($this->_params['show_filter_msg'] &&
                             !($fetch = $api->fetchEnvelope($indices))) {
-                            continue 2;
+                            break;
                         }
 
                         $mbox = new Horde_Imap_Client_Mailbox($rule->value);


### PR DESCRIPTION
Fix of an error reported by Michael Schlueter: 'PHP message: PHP Warning:  "continue 2" targeting switch is equivalent to "break 2". Did you mean to use "continue 3"? in /srv/www/horde/vendor/horde/ingo/lib/Script/Imap.php on line 279;

adjusting this switch case error handling similar to the sibling cases.

breaking the switch ends anyway the iteration and continues with the next out loop iteration, as nothing follows afte the switch structure.