### PR TITLE
fix: Add return type declarations to satisfy Countable and IteratorAggregate interface requirements

### DIFF
--- a/lib/Storage.php
+++ b/lib/Storage.php
@@ -381,7 +381,7 @@ abstract class Ingo_Storage implements Countable, IteratorAggregate
 
     /**
      */
-    public function count()
+    public function count(): int
     {
         $this->_load();
 
@@ -392,7 +392,7 @@ abstract class Ingo_Storage implements Countable, IteratorAggregate
 
     /**
      */
-    public function getIterator()
+    public function getIterator(): Traversable
     {
         $this->_load();
 


### PR DESCRIPTION
Do we need a review of changes like that?