### PR TITLE
feat(sieve): Support XOAUTH2 in Timsieved transport

### DIFF
--- a/lib/Factory/Transport.php
+++ b/lib/Factory/Transport.php
@@ -51,7 +51,10 @@ class Ingo_Factory_Transport extends Horde_Core_Factory_Base
             $auth = [];
         }
 
-        if (!isset($auth['password'])) {
+        $hasXoauth2 = isset($auth['xoauth2_token']) && 
+                      $auth['xoauth2_token'] instanceof \Horde\ManageSieve\Password\Xoauth2;
+
+        if (!$hasXoauth2 && !isset($auth['password'])) {
             $auth['password'] = $registry->getAuthCredential('password');
         }
         if (!isset($auth['username'])) {

--- a/lib/Transport/Timsieved.php
+++ b/lib/Transport/Timsieved.php
@@ -74,18 +74,39 @@ class Ingo_Transport_Timsieved extends Ingo_Transport_Base
             : $this->_params['admin'];
 
         try {
-            $this->_sieve = new ManageSieve([
-                'user'       => $auth,
-                'password'   => $this->_params['password'],
-                'host'       => $this->_params['hostspec'],
-                'port'       => $this->_params['port'],
-                'authmethod' => $this->_params['logintype'],
-                'euser'      => $this->_params['euser'],
-                'secure'     => $this->_params['usetls'],
-                'logger'     => $this->_params['debug']
-                    ? $injector->getInstance('Horde_Log_Logger')
-                    : null,
-            ]);
+            // Check if we have XOAUTH2 token
+            if (isset($this->_params['xoauth2_token']) &&
+                $this->_params['xoauth2_token'] instanceof \Horde\ManageSieve\Password\Xoauth2) {
+                // XOAUTH2 authentication - pass token directly
+                $authMethod = \Horde\ManageSieve\Client::AUTH_XOAUTH2;
+
+                $this->_sieve = new ManageSieve([
+                    'user'         => $auth,
+                    'xoauth2_token' => $this->_params['xoauth2_token'],
+                    'host'         => $this->_params['hostspec'],
+                    'port'         => $this->_params['port'],
+                    'authmethod'   => $authMethod,
+                    'euser'        => $this->_params['euser'],
+                    'secure'       => $this->_params['usetls'],
+                    'logger'       => $this->_params['debug']
+                        ? $injector->getInstance('Horde_Log_Logger')
+                        : null,
+                ]);
+            } else {
+                // Normal password authentication
+                $this->_sieve = new ManageSieve([
+                    'user'       => $auth,
+                    'password'   => $this->_params['password'],
+                    'host'       => $this->_params['hostspec'],
+                    'port'       => $this->_params['port'],
+                    'authmethod' => $this->_params['logintype'],
+                    'euser'      => $this->_params['euser'],
+                    'secure'     => $this->_params['usetls'],
+                    'logger'     => $this->_params['debug']
+                        ? $injector->getInstance('Horde_Log_Logger')
+                        : null,
+                ]);
+            }
         } catch (ManageSieveException $e) {
             throw new Ingo_Exception($e);
         }


### PR DESCRIPTION
  #### Summary                                                                    
                                                                                  
  This PR enables XOAUTH2 authentication in Ingo's ManageSieve (Timsieved)        
  transport, using the existing  transport_auth  hook — no new hook is            
  introduced.                                                                     
                                                                                  
  #### Context                                                                    
                                                                                  
  Cyrus IMAP deployments using OAuth2/OIDC single sign-on (SASL XOAUTH2)          
  do not have user passwords available. The existing  transport_auth  hook        
  already allows third-party code to inject custom credentials; this PR           
  extends the plumbing so that when the hook returns an  xoauth2_token            
  key, the Timsieved transport uses  AUTH_XOAUTH2  instead of a plaintext         
  password.                                                                       
                                                                                  
  This PR is a prerequisite for a forthcoming OIDC authentication driver          
  for Horde. A hook implementing  transport_auth  for OIDC will supply a          
   Horde\ManageSieve\Password\Xoauth2  object; without this PR, the token         
  would be silently ignored and authentication would fall back (and fail)         
  with a password prompt.                                                         
                                                                                  
  This PR is self-contained: it adds no new hooks, no new                         
  dependencies, and does not alter the code path for password-based               
  authentication. If no  xoauth2_token  key is present in the hook                
  result, behaviour is identical to the current code.                             
                                                                                  
  #### Changes                                                                    
                                                                                  
   lib/Transport/Timsieved.php  —  _connect()  now checks whether                 
   $this->_params['xoauth2_token']  is a                                          
   Horde\ManageSieve\Password\Xoauth2  instance. If so, it passes                 
   xoauth2_token  to the ManageSieve client constructor and sets                  
   authmethod  to  Client::AUTH_XOAUTH2 . The existing password path is           
  unchanged.                                                                      
                                                                                  
   lib/Factory/Transport.php  — the factory no longer unconditionally             
  overwrites a missing  password  key with the session credential when            
   xoauth2_token  is already present. This prevents an unnecessary (and           
  potentially failing) call to  $registry->getAuthCredential('password')          
  in XOAUTH2-only sessions.                                                       
                                                                                  
  #### Dependency                                                                 
                                                                                  
  Requires  horde/ManageSieve  PR "feat(auth): add XOAUTH2 authentication support to ManageSieve client"            
  (or equivalent changes) to be merged first, as                                  
   Horde\ManageSieve\Password\Xoauth2  and  Client::AUTH_XOAUTH2  are             
  defined there.                                                                  
                                                                                  
  #### Tests                                                                      
                                                                                  
  No new tests in this PR. The Timsieved transport requires a live                
  ManageSieve server; its integration is covered by manual testing against        
  Cyrus IMAP with  cyrus-sasl-oauth2.                                     
                                                                  