### PR TITLE
fix(security): restrict unserialize allowed_classes (ZDI-20-1051)

### DIFF
--- a/lib/LoginTasks/SystemTask/Upgrade.php
+++ b/lib/LoginTasks/SystemTask/Upgrade.php
@@ -59,7 +59,7 @@ class Ingo_LoginTasks_SystemTask_Upgrade extends Horde_Core_LoginTasks_SystemTas
     {
         global $prefs;
 
-        if (!($old_rules = @unserialize($prefs->getValue('rules')))) {
+        if (!($old_rules = @unserialize($prefs->getValue('rules'), ['allowed_classes' => false]))) {
             $old_rules = [];
         }
 
@@ -85,7 +85,7 @@ class Ingo_LoginTasks_SystemTask_Upgrade extends Horde_Core_LoginTasks_SystemTas
             switch ($val['action']) {
                 case 7: // ACTION_BLACKLIST
                     $ob = new Ingo_Rule_System_Blacklist();
-                    if ($data = @unserialize($prefs->getValue('blacklist'))) {
+                    if ($data = @unserialize($prefs->getValue('blacklist'), ['allowed_classes' => false])) {
                         $ob->addresses = $data['a'];
                         $ob->mailbox = $data['f'];
                     }
@@ -101,7 +101,7 @@ class Ingo_LoginTasks_SystemTask_Upgrade extends Horde_Core_LoginTasks_SystemTas
 
                 case 10: // ACTION_FORWARD
                     $ob = new Ingo_Rule_System_Forward();
-                    if ($data = @unserialize($prefs->getValue('forward'))) {
+                    if ($data = @unserialize($prefs->getValue('forward'), ['allowed_classes' => false])) {
                         $ob->addresses = $data['a'];
                         $ob->keep = !empty($data['k']);
                     }
@@ -137,7 +137,7 @@ class Ingo_LoginTasks_SystemTask_Upgrade extends Horde_Core_LoginTasks_SystemTas
 
                 case 14: // ACTION_SPAM
                     $ob = new Ingo_Rule_System_Spam();
-                    if ($data = @unserialize($prefs->getValue('spam'))) {
+                    if ($data = @unserialize($prefs->getValue('spam'), ['allowed_classes' => false])) {
                         $ob->level = $data['level'];
                         $ob->mailbox = $data['folder'];
                     } else {
@@ -147,7 +147,7 @@ class Ingo_LoginTasks_SystemTask_Upgrade extends Horde_Core_LoginTasks_SystemTas
 
                 case 8: // ACTION_VACATION
                     $ob = new Ingo_Rule_System_Vacation();
-                    if ($data = @unserialize($prefs->getValue('vacation'))) {
+                    if ($data = @unserialize($prefs->getValue('vacation'), ['allowed_classes' => false])) {
                         $ob->addresses = $data['addresses'];
                         $ob->days = $data['days'];
                         $ob->exclude = $data['excludes'];
@@ -167,7 +167,7 @@ class Ingo_LoginTasks_SystemTask_Upgrade extends Horde_Core_LoginTasks_SystemTas
 
                 case 9: // ACTION_WHITELIST
                     $ob = new Ingo_Rule_System_Whitelist();
-                    if ($data = @unserialize($prefs->getValue('whitelist'))) {
+                    if ($data = @unserialize($prefs->getValue('whitelist'), ['allowed_classes' => false])) {
                         $ob->addresses = $data;
                     }
                     break;

--- a/lib/Storage/Mongo.php
+++ b/lib/Storage/Mongo.php
@@ -80,7 +80,25 @@ class Ingo_Storage_Mongo extends Ingo_Storage implements Horde_Mongo_Collection_
 
             if (isset($res['result'])) {
                 foreach ($res['result'] as $val) {
-                    if ($ob = @unserialize($val[self::DATA])) {
+                    if ($ob = @unserialize($val[self::DATA], ['allowed_classes' => [
+                        'Ingo_Rule',
+                        'Ingo_Rule_Addresses',
+                        'Ingo_Rule_System_Blacklist',
+                        'Ingo_Rule_System_Forward',
+                        'Ingo_Rule_System_Spam',
+                        'Ingo_Rule_System_Vacation',
+                        'Ingo_Rule_System_Whitelist',
+                        'Ingo_Rule_User',
+                        'Ingo_Rule_User_Discard',
+                        'Ingo_Rule_User_FlagOnly',
+                        'Ingo_Rule_User_Keep',
+                        'Ingo_Rule_User_Move',
+                        'Ingo_Rule_User_MoveKeep',
+                        'Ingo_Rule_User_Notify',
+                        'Ingo_Rule_User_Redirect',
+                        'Ingo_Rule_User_RedirectKeep',
+                        'Ingo_Rule_User_Reject',
+                    ]])) {
                         $ob->uid = strval($val[self::MONGO_ID]);
                         $this->_rules[] = $ob;
                     }

--- a/lib/Storage/Prefs.php
+++ b/lib/Storage/Prefs.php
@@ -29,7 +29,25 @@ class Ingo_Storage_Prefs extends Ingo_Storage
      */
     protected function _loadFromBackend()
     {
-        if ($rules = @unserialize($this->_prefs()->getValue('rules'))) {
+        if ($rules = @unserialize($this->_prefs()->getValue('rules'), ['allowed_classes' => [
+            'Ingo_Rule',
+            'Ingo_Rule_Addresses',
+            'Ingo_Rule_System_Blacklist',
+            'Ingo_Rule_System_Forward',
+            'Ingo_Rule_System_Spam',
+            'Ingo_Rule_System_Vacation',
+            'Ingo_Rule_System_Whitelist',
+            'Ingo_Rule_User',
+            'Ingo_Rule_User_Discard',
+            'Ingo_Rule_User_FlagOnly',
+            'Ingo_Rule_User_Keep',
+            'Ingo_Rule_User_Move',
+            'Ingo_Rule_User_MoveKeep',
+            'Ingo_Rule_User_Notify',
+            'Ingo_Rule_User_Redirect',
+            'Ingo_Rule_User_RedirectKeep',
+            'Ingo_Rule_User_Reject',
+        ]])) {
             $this->_rules = $rules;
         }
     }

--- a/lib/Storage/Sql.php
+++ b/lib/Storage/Sql.php
@@ -227,7 +227,8 @@ class Ingo_Storage_Sql extends Ingo_Storage
                             unserialize(
                                 $columns['rule_conditions']->binaryToString(
                                     $row['rule_conditions']
-                                )
+                                ),
+                                ['allowed_classes' => false]
                             ),
                             $this->_params['charset'],
                             'UTF-8'


### PR DESCRIPTION
## Summary

- Restrict all `unserialize()` calls to prevent PHP object injection (ZDI-20-1051)
- Storage backends (Prefs, Mongo) that deserialize rule objects now whitelist only the known Ingo_Rule class hierarchy (Ingo_Rule, Ingo_Rule_Addresses, all System and User subclasses)
- Storage/Sql `rule_conditions` and all legacy prefs in the v4 upgrade task (blacklist, forward, spam, vacation, whitelist, old rules format) use `allowed_classes: false` since they store only arrays