### PR TITLE
fix(ingo): register Ingo\ PSR-4 autoload for V3 form types

### DIFF
--- a/.horde.yml
+++ b/.horde.yml
@@ -68,6 +68,7 @@ autoload:
     - lib/
   psr-4:
     Horde\Ingo\: src/
+    Ingo\: src/
 vendor: horde
 keywords:
   - filter

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
             "lib/"
         ],
         "psr-4": {
-            "Horde\\Ingo\\": "src/"
+            "Horde\\Ingo\\": "src/",
+            "Ingo\\": "src/"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
## Summary
- Register `Ingo\` → `src/` PSR-4 autoload in composer.json and .horde.yml
- Fixes fatal error on Forward, Vacation, and Spam filter pages

## Motivation
After the V3 form migration (91cbbb2), custom field types live in
`Ingo\Form\V3\LongemailVariable` and `Ingo\Form\V3\FoldersVariable`.
`Horde_Form::createVariable()` looks up `{App}\Form\V3\{Type}Variable`,
but only `Horde\Ingo\` was autoloaded from `src/`, so pages using
`ingo:Longemail` or `ingo:folders` crashed with "Nonexistent class
Ingo_Form_Type_Longemail".

## Changes
- Add `"Ingo\\": "src/"` to autoload.psr-4 in composer.json
- Mirror the mapping in .horde.yml

## Test plan
- [ ] Open Ingo → Forward — form loads without fatal error
- [ ] Open Ingo → Vacation — form loads without fatal error
- [ ] Open Ingo → Spam — folder selector loads without fatal error
- [ ] Enter invalid email in Longemail field — validation message shown

Made with [Cursor](https://cursor.com)